### PR TITLE
Ensure all test files are distributed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE README.md requirements.txt
 include versioneer.py
 include cwinpy/_version.py
+recursive-include test/ *.py
+recursive-include test/data *


### PR DESCRIPTION
This MR modifies the `MANIFEST.in` file to include all necessary test scripts and data files, so that the pytest suite can be run from the tarball. This should be used in the conda build, for example.