### PR TITLE
Replace deprecated numpy aliases with builtins

### DIFF
--- a/cwinpy/data.py
+++ b/cwinpy/data.py
@@ -917,11 +917,11 @@ class HeterodynedData(TimeSeriesBase):
                         dataarray = dataarray.T
                 else:
                     # set data to zeros
-                    dataarray = np.zeros((len(hettimes), 1), dtype=np.complex)
+                    dataarray = np.zeros((len(hettimes), 1), dtype=complex)
 
                 if (
                     dataarray.shape[1] == 1
-                    and dataarray.dtype == np.complex
+                    and dataarray.dtype == complex
                     and hettimes is not None
                 ):
                     dataarray = dataarray.flatten()
@@ -1261,7 +1261,7 @@ class HeterodynedData(TimeSeriesBase):
             raise ValueError("The running median window must be greater than 1")
 
         self._running_median = TimeSeriesBase(
-            np.zeros(len(self), dtype=np.complex), times=self.times
+            np.zeros(len(self), dtype=complex), times=self.times
         )
         if N > 0:
             for i in range(len(self)):
@@ -3043,7 +3043,7 @@ class HeterodynedData(TimeSeriesBase):
         tidxs = np.where(np.in1d(newtimes, times))[0]
 
         # get zero array and add data
-        padded = np.zeros(len(newtimes), dtype=np.complex)
+        padded = np.zeros(len(newtimes), dtype=complex)
         padded[tidxs] = data
 
         return padded

--- a/cwinpy/data.py
+++ b/cwinpy/data.py
@@ -2297,9 +2297,9 @@ class HeterodynedData(TimeSeriesBase):
 
         idx = np.asarray(mask)
         if idx.dtype == int:
-            zidx = np.ones(len(self), dtype=np.bool)
+            zidx = np.ones(len(self), dtype=bool)
             zidx[idx] = False
-        elif idx.dtype == np.bool:
+        elif idx.dtype == bool:
             if len(idx) != len(self):
                 raise ValueError("Outlier mask is the wrong size")
             else:

--- a/cwinpy/data.py
+++ b/cwinpy/data.py
@@ -1401,7 +1401,7 @@ class HeterodynedData(TimeSeriesBase):
                 ).astype("int")
             else:
                 if len(self.change_point_indices) == 1:
-                    cps = np.array([0, len(datasub)], dtype=np.int)
+                    cps = np.array([0, len(datasub)], dtype=int)
                 else:
                     cps = np.concatenate(
                         (self.change_point_indices, [len(datasub)])
@@ -2296,7 +2296,7 @@ class HeterodynedData(TimeSeriesBase):
             return
 
         idx = np.asarray(mask)
-        if idx.dtype == np.int:
+        if idx.dtype == int:
             zidx = np.ones(len(self), dtype=np.bool)
             zidx[idx] = False
         elif idx.dtype == np.bool:

--- a/cwinpy/iostream/readers.py
+++ b/cwinpy/iostream/readers.py
@@ -98,7 +98,7 @@ def read_hdf5_series(
     except KeyError:
         dt = kwargs.pop("dx")
     if timespans is not None:
-        times = np.array([], dtype=np.float)
+        times = np.array([], dtype=float)
         for ts in timespans:
             times = np.concatenate((times, np.arange(ts[0], ts[1] + dt / 2, dt)))
         kwargs["times"] = times

--- a/cwinpy/utils.py
+++ b/cwinpy/utils.py
@@ -60,7 +60,7 @@ def gcd_array(denominators):
         raise TypeError("Must have a list or array")
 
     denoms = np.asarray(denominators).flatten()  # 1d array
-    denoms = denoms.astype(np.int)
+    denoms = denoms.astype(int)
 
     if len(denoms) < 2:
         raise ValueError("Must have more than two values")


### PR DESCRIPTION
This PR resolves a number of `DeprecationWarning`s from `numpy` by replacing deprecated aliases of builtins with the relevant builtins themselves, see https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated for details.